### PR TITLE
Fix: Can't call setState on an unmounted component

### DIFF
--- a/src/lib/components/Camera/index.js
+++ b/src/lib/components/Camera/index.js
@@ -53,6 +53,7 @@ class Camera extends React.Component {
   }
 
   componentWillUnmount () {
+    this.showVideoTimeout && clearInterval(this.showVideoTimeout);
     const isComponentWillUnmount = true;
     this.stopCamera(isComponentWillUnmount)
       .catch((error) => {
@@ -141,7 +142,8 @@ class Camera extends React.Component {
       isShowVideo: false
     });
 
-    setTimeout(() => {
+    this.showVideoTimeout && clearInterval(this.showVideoTimeout);
+    this.showVideoTimeout = setTimeout(() => {
       this.setState({
         isShowVideo: true
       });


### PR DESCRIPTION
Scenario: If you take a picture and immediately unmount the component,
there is a `setTimeout` which sets some property in the state of the
Camera component.

This commit introduces a variable to store the timer and clear it on
unmount.