### PR TITLE
Prevent react string warning for boolean attribute

### DIFF
--- a/src/lib/components/Camera/index.js
+++ b/src/lib/components/Camera/index.js
@@ -172,7 +172,7 @@ class Camera extends React.Component {
         <video
           style={videoStyles}
           ref={this.videoRef}
-          autoPlay="true"
+          autoPlay={true}
           playsInline
         />
         <CircleButton


### PR DESCRIPTION
Fixes #16 

From the JS console: 

    Warning: Received the string `true` for the boolean attribute `autoPlay`. Although this works, it will not work as expected if you pass the string "false". Did you mean autoPlay={true}?