### PR TITLE
Allow enumerating devices and specifying a specific device

### DIFF
--- a/src/lib/components/Camera/hooks/useLibCameraPhoto.js
+++ b/src/lib/components/Camera/hooks/useLibCameraPhoto.js
@@ -4,7 +4,7 @@ import LibCameraPhoto from 'jslib-html5-camera-photo';
 let libCameraPhoto = null;
 let needToClean = false;
 
-export function useLibCameraPhoto (videoRef, idealFacingMode, idealResolution, isMaxResolution) {
+export function useLibCameraPhoto (videoRef, idealFacingMode, idealResolution, isMaxResolution, idealDeviceId) {
   const [mediaStream, setMediaStream] = useState(null);
   const [cameraStartError, setCameraStartError] = useState(null);
   const [cameraStopError, setCameraStopError] = useState(null);
@@ -23,7 +23,7 @@ export function useLibCameraPhoto (videoRef, idealFacingMode, idealResolution, i
         if (isMaxResolution) {
           _mediaStream = await libCameraPhoto.startCameraMaxResolution(idealFacingMode);
         } else {
-          _mediaStream = await libCameraPhoto.startCamera(idealFacingMode, idealResolution);
+          _mediaStream = await libCameraPhoto.startCamera(idealFacingMode, idealResolution, idealDeviceId);
         }
         setMediaStream(_mediaStream);
         setCameraStartError(null);
@@ -53,11 +53,11 @@ export function useLibCameraPhoto (videoRef, idealFacingMode, idealResolution, i
         }
       };
     }
-  }, [videoRef, mediaStream, idealFacingMode, idealResolution, isMaxResolution]);
+  }, [videoRef, mediaStream, idealFacingMode, idealResolution, idealDeviceId, isMaxResolution]);
 
   function getDataUri (configDataUri) {
     return libCameraPhoto.getDataUri(configDataUri);
   }
 
-  return [mediaStream, cameraStartError, cameraStopError, getDataUri];
+  return [mediaStream, cameraStartError, cameraStopError, getDataUri, libCameraPhoto];
 }

--- a/src/lib/components/Camera/index.js
+++ b/src/lib/components/Camera/index.js
@@ -36,13 +36,14 @@ function Camera (props) {
     mediaStream,
     cameraStartError,
     cameraStopError,
-    getDataUri
-  ] = useLibCameraPhoto(videoRef, props.idealFacingMode, props.idealResolution, props.isMaxResolution);
+    getDataUri,
+    cameraPhoto
+  ] = useLibCameraPhoto(videoRef, props.idealFacingMode, props.idealResolution, props.isMaxResolution, props.idealDeviceId);
 
   useEffect(() => {
     if (mediaStream) {
       if (typeof props.onCameraStart === 'function') {
-        props.onCameraStart(mediaStream);
+        props.onCameraStart(mediaStream, cameraPhoto);
       }
     } else {
       if (typeof props.onCameraStop === 'function') {
@@ -149,6 +150,7 @@ Camera.propTypes = {
   onTakePhoto: PropTypes.func,
   onTakePhotoAnimationDone: PropTypes.func,
   onCameraError: PropTypes.func,
+  idealDeviceId: PropTypes.string,
   idealFacingMode: PropTypes.string,
   idealResolution: PropTypes.object,
   imageType: PropTypes.string,


### PR DESCRIPTION
- Accept a new prop idealDeviceId which will pick that specific device if it is available
- Pass back a handle to the camera photo object so that the current deviceId and available devices are accessible

Depends on https://github.com/MABelanger/jslib-html5-camera-photo/pull/35 being merged & released in order to work fully
